### PR TITLE
Fix filtering by policy_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
-## x.y.z - YYYY-MM-DD
-
-### Added
-- Lorem ipsum dolor sit amet
-
-### Deprecated
-- Nothing.
-
-### Removed
-- Nothing.
+## 1.0.1 - 2016-06-27
 
 ### Fixed
-- Nothing.
+- Patch edit to fix issue where filtering on policy id didn't work properly

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-new-relic-alerts",
   "description": "A hubot script to tell your team of today's New Relic warnings and violations",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Kimberly Munoz <kimberly.munoz@cfpb.gov>",
   "license": "CC0",
   "keywords": [

--- a/src/new-relic-alerts.coffee
+++ b/src/new-relic-alerts.coffee
@@ -42,7 +42,7 @@ checkNewRelic = (robot) ->
     body.violations.forEach (el) ->
       countWarningsViolations(el) if not process.env.HUBOT_NEW_RELIC_POLICY_ID
 
-      countWarningsViolations(el) if el.links.policy_id == process.env.HUBOT_NEW_RELIC_POLICY_ID
+      countWarningsViolations(el) if el.links.policy_id == Number(process.env.HUBOT_NEW_RELIC_POLICY_ID)
 
     msg = "Daily performance update! There are #{numOfWarnings} performance warnings and #{numOfViolations} performance policy violations today. Check them out at #{newRelicURL}"
 


### PR DESCRIPTION
Before this fix, any message with filtering would return 0 warnings and
violations. By converting the env variable to a number, the filtering
should work properly.
## Review
- @contolini 

[Preview this PR without the whitespace changes](?w=0)
