### PR TITLE
Add a table of violations in addition to the counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "hubot": "^2.18.0",
     "hubot-test-helper": "^1.4.4",
     "matchdep": "~1.0.1",
+    "moment": "2.10.2",
     "mocha": "^2.4.5",
+    "quick-gist": "^1.3.1",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0"
   },


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request

## Additions

- Adds a table of alert violations to the nightly output

## Removals

- None

## Changes

- Adds `open_only=true` to the API call to avoid pulling in closed violations

## Testing

- Adds a quickie tester robot listener

## Review

- @contolini 
